### PR TITLE
Update the pv-site-api command to use poetry

### DIFF
--- a/terraform/modules/services/api_pvsite/docker-compose.yml
+++ b/terraform/modules/services/api_pvsite/docker-compose.yml
@@ -10,6 +10,6 @@ services:
       ORIGINS: $ORIGINS
       FAKE: $FAKE
     container_name: nowcasting_api
-    command: ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "80"]
+    command: ["poetry", "run", "uvicorn", "pv_site_api.main:app", "--host", "0.0.0.0", "--port", "80"]
     ports:
       - 80:80


### PR DESCRIPTION
The docker as built by https://github.com/openclimatefix/pv-site-api now uses poetry.