### PR TITLE
Rds random page costs

### DIFF
--- a/terraform/modules/storage/database-pair/rds.tf
+++ b/terraform/modules/storage/database-pair/rds.tf
@@ -20,7 +20,7 @@ resource "aws_db_instance" "db-forecast" {
   performance_insights_enabled = true
   iops                         = 3000
   storage_type                 = "gp3"
-  parameter_group_name         = aws_db_parameter_group.forecast-parameter-group.name
+  parameter_group_name         = aws_db_parameter_group.parameter-group.name
 
   tags = {
     Name        = "${var.environment}-rds"
@@ -51,7 +51,7 @@ resource "aws_db_instance" "db-pv" {
   allow_major_version_upgrade  = true
   iops                         = 3000
   storage_type                 = "gp3"
-  parameter_group_name         = aws_db_parameter_group.pv-parameter-group.name
+  parameter_group_name         = aws_db_parameter_group.parameter-group.name
 
   tags = {
     Name        = "${var.environment}-rds"
@@ -60,9 +60,9 @@ resource "aws_db_instance" "db-pv" {
 
 }
 
-resource "aws_db_parameter_group" "forecast-parameter-group" {
+resource "aws_db_parameter_group" "parameter-group" {
   name   = "forecast${var.environment}-parameter-group"
-  family = "postgres15.2"
+  family = "postgres15"
 
   parameter {
     name  = "random_page_cost"
@@ -71,14 +71,3 @@ resource "aws_db_parameter_group" "forecast-parameter-group" {
 
 }
 
-
-resource "aws_db_parameter_group" "pv-parameter-group" {
-  name   = "pv${var.environment}-parameter-group"
-  family = "postgres15.2"
-
-  parameter {
-    name  = "random_page_cost"
-    value = "1.1"
-  }
-
-}

--- a/terraform/modules/storage/database-pair/rds.tf
+++ b/terraform/modules/storage/database-pair/rds.tf
@@ -20,7 +20,7 @@ resource "aws_db_instance" "db-forecast" {
   performance_insights_enabled = true
   iops                         = 3000
   storage_type                 = "gp3"
-  parameter_group_name         = aws_db_parameter_group.forecast-parameter-group
+  parameter_group_name         = aws_db_parameter_group.forecast-parameter-group.name
 
   tags = {
     Name        = "${var.environment}-rds"
@@ -51,7 +51,7 @@ resource "aws_db_instance" "db-pv" {
   allow_major_version_upgrade  = true
   iops                         = 3000
   storage_type                 = "gp3"
-  parameter_group_name         = aws_db_parameter_group.pv-parameter-group
+  parameter_group_name         = aws_db_parameter_group.pv-parameter-group.name
 
   tags = {
     Name        = "${var.environment}-rds"

--- a/terraform/modules/storage/database-pair/rds.tf
+++ b/terraform/modules/storage/database-pair/rds.tf
@@ -20,6 +20,7 @@ resource "aws_db_instance" "db-forecast" {
   performance_insights_enabled = true
   iops                         = 3000
   storage_type                 = "gp3"
+  parameter_group_name         = aws_db_parameter_group.forecast-parameter-group
 
   tags = {
     Name        = "${var.environment}-rds"
@@ -50,10 +51,34 @@ resource "aws_db_instance" "db-pv" {
   allow_major_version_upgrade  = true
   iops                         = 3000
   storage_type                 = "gp3"
+  parameter_group_name         = aws_db_parameter_group.pv-parameter-group
 
   tags = {
     Name        = "${var.environment}-rds"
     Environment = "var.environment"
+  }
+
+}
+
+resource "aws_db_parameter_group" "forecast-parameter-group" {
+  name   = "forecast${var.environment}-parameter-group"
+  family = "postgres15.2"
+
+  parameter {
+    name  = "random_page_cost"
+    value = "1.1"
+  }
+
+}
+
+
+resource "aws_db_parameter_group" "pv-parameter-group" {
+  name   = "pv${var.environment}-parameter-group"
+  family = "postgres15.2"
+
+  parameter {
+    name  = "random_page_cost"
+    value = "1.1"
   }
 
 }

--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -20,7 +20,7 @@ resource "aws_db_instance" "postgres-db" {
   performance_insights_enabled = true
   allow_major_version_upgrade  = var.allow_major_version_upgrade
   storage_type                 = "gp3"
-  parameter_group_name         = aws_db_parameter_group.parameter-group
+  parameter_group_name         = aws_db_parameter_group.parameter-group.name
 
   tags = {
     Name        = "${var.environment}-rds"

--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -31,7 +31,7 @@ resource "aws_db_instance" "postgres-db" {
 
 resource "aws_db_parameter_group" "parameter-group" {
   name   = "forecast${var.environment}-parameter-group"
-  family = "postgres15.2"
+  family = "postgres15"
 
   parameter {
     name  = "random_page_cost"

--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -20,6 +20,7 @@ resource "aws_db_instance" "postgres-db" {
   performance_insights_enabled = true
   allow_major_version_upgrade  = var.allow_major_version_upgrade
   storage_type                 = "gp3"
+  parameter_group_name         = aws_db_parameter_group.parameter-group
 
   tags = {
     Name        = "${var.environment}-rds"
@@ -27,3 +28,15 @@ resource "aws_db_instance" "postgres-db" {
   }
 
 }
+
+resource "aws_db_parameter_group" "parameter-group" {
+  name   = "forecast${var.environment}-parameter-group"
+  family = "postgres15.2"
+
+  parameter {
+    name  = "random_page_cost"
+    value = "1.1"
+  }
+
+}
+


### PR DESCRIPTION
# Pull Request

## Description

add parameter group for each database, 
- random_page_cost=1.1. The deafult is 4, but because we are using gp3 fast storage, we should encourage the databse to read more things in storage

Fixes #186 

## How Has This Been Tested?

CI plans
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
