### PR TITLE
Iops fix

### DIFF
--- a/terraform/modules/storage/database-pair/rds.tf
+++ b/terraform/modules/storage/database-pair/rds.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "db-forecast" {
   db_subnet_group_name         = var.db_subnet_group.name # update name with private/public
   auto_minor_version_upgrade   = true
   performance_insights_enabled = true
-  iops                         = 3000
+  iops                         = null # https://github.com/hashicorp/terraform-provider-aws/issues/28271
   storage_type                 = "gp3"
 
   tags = {
@@ -48,7 +48,7 @@ resource "aws_db_instance" "db-pv" {
   auto_minor_version_upgrade   = true
   performance_insights_enabled = true
   allow_major_version_upgrade  = true
-  iops                         = 3000
+  iops                         = null # https://github.com/hashicorp/terraform-provider-aws/issues/28271
   storage_type                 = "gp3"
 
   tags = {

--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -20,6 +20,7 @@ resource "aws_db_instance" "postgres-db" {
   performance_insights_enabled = true
   allow_major_version_upgrade  = var.allow_major_version_upgrade
   storage_type                 = "gp3"
+  iops                         = null # https://github.com/hashicorp/terraform-provider-aws/issues/28271
 
   tags = {
     Name        = "${var.environment}-rds"


### PR DESCRIPTION
In order to enable the upgrade to GP3 storage, we have to prevent specifying the IOPS (it defaults to 3000) via a null call, see https://github.com/hashicorp/terraform-provider-aws/issues/28271