### PR TITLE
Bump AWS provider to 4.47.0

### DIFF
--- a/terraform/modules/storage/database-pair/rds.tf
+++ b/terraform/modules/storage/database-pair/rds.tf
@@ -18,7 +18,6 @@ resource "aws_db_instance" "db-forecast" {
   db_subnet_group_name         = var.db_subnet_group.name # update name with private/public
   auto_minor_version_upgrade   = true
   performance_insights_enabled = true
-  iops                         = 3000 # null # https://github.com/hashicorp/terraform-provider-aws/issues/28271
   storage_type                 = "gp3"
   parameter_group_name         = aws_db_parameter_group.parameter-group.name
 
@@ -49,7 +48,6 @@ resource "aws_db_instance" "db-pv" {
   auto_minor_version_upgrade   = true
   performance_insights_enabled = true
   allow_major_version_upgrade  = true
-  iops                         = 3000 # null # https://github.com/hashicorp/terraform-provider-aws/issues/28271
   storage_type                 = "gp3"
   parameter_group_name         = aws_db_parameter_group.parameter-group.name
 
@@ -70,4 +68,3 @@ resource "aws_db_parameter_group" "parameter-group" {
   }
 
 }
-

--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -20,7 +20,6 @@ resource "aws_db_instance" "postgres-db" {
   performance_insights_enabled = true
   allow_major_version_upgrade  = var.allow_major_version_upgrade
   storage_type                 = "gp3"
-  iops                         = 3000 # null https://github.com/hashicorp/terraform-provider-aws/issues/28271
   parameter_group_name         = aws_db_parameter_group.parameter-group.name
 
   tags = {
@@ -40,4 +39,3 @@ resource "aws_db_parameter_group" "parameter-group" {
   }
 
 }
-

--- a/terraform/nowcasting/development/provider.tf
+++ b/terraform/nowcasting/development/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.45.0"
+      version = "~> 4.47.0"
     }
 
     cloudflare = {

--- a/terraform/nowcasting/production/provider.tf
+++ b/terraform/nowcasting/production/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.45.0"
+      version = "~> 4.47.0"
     }
 
     cloudflare = {

--- a/terraform/pvsite/development/provider.tf
+++ b/terraform/pvsite/development/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.45.0"
+      version = "~> 4.47.0"
     }
   }
 

--- a/terraform/pvsite/production/provider.tf
+++ b/terraform/pvsite/production/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.45.0"
+      version = "~> 4.47.0"
     }
   }
 


### PR DESCRIPTION
Hopefully resolves the IOPS issue with GP3 storage. If this doesn't work, then we might have to use the community RDS module.
