### PR TITLE
Sunset development branch

### DIFF
--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -4,12 +4,12 @@ Variables used across all modules
 locals {
   production_availability_zones = ["${var.region}a", "${var.region}b", "${var.region}c"]
   domain = "nowcasting"
+  modules_url = "github.com/openclimatefix/ocf-infrastructure//terraform/modules"
 }
 
 
 module "networking" {
-  source = "../../modules/networking"
-
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/networking?ref=5b7005f"
   region               = var.region
   environment          = var.environment
   vpc_cidr             = var.vpc_cidr
@@ -19,7 +19,7 @@ module "networking" {
 }
 
 module "ec2-bastion" {
-  source = "../../modules/networking/ec2_bastion"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/networking/ec2_bastion?ref=5b7005f"
 
   region               = var.region
   vpc_id               = module.networking.vpc_id
@@ -27,7 +27,7 @@ module "ec2-bastion" {
 }
 
 module "s3" {
-  source = "../../modules/storage/s3-trio"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/storage/s3-trio?ref=5b7005f"
 
   region      = var.region
   environment = var.environment
@@ -35,15 +35,14 @@ module "s3" {
 }
 
 module "ecs" {
-  source = "../../modules/ecs"
-
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/ecs?ref=5b7005f"
   region      = var.region
   environment = var.environment
   domain = local.domain
 }
 
 module "forecasting_models_bucket" {
-  source = "../../modules/storage/s3-private"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/storage/s3-private?ref=5b7005f"
 
   region              = var.region
   environment         = var.environment
@@ -53,7 +52,7 @@ module "forecasting_models_bucket" {
 }
 
 module "api" {
-  source = "../../modules/services/api"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/api?ref=5b7005f"
 
   region                              = var.region
   environment                         = var.environment
@@ -73,7 +72,7 @@ module "api" {
 
 
 module "database" {
-  source = "../../modules/storage/database-pair"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/storage/database-pair?ref=5b7005f"
 
   region          = var.region
   environment     = var.environment
@@ -82,7 +81,7 @@ module "database" {
 }
 
 module "nwp" {
-  source = "../../modules/services/nwp"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/nwp?ref=5b7005f"
 
   region                  = var.region
   environment             = var.environment
@@ -101,7 +100,7 @@ module "nwp" {
 }
 
 module "nwp-national" {
-  source = "../../modules/services/nwp"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/nwp?ref=5b7005f"
 
   region                  = var.region
   environment             = var.environment
@@ -120,7 +119,7 @@ module "nwp-national" {
 }
 
 module "sat" {
-  source = "../../modules/services/sat"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/sat?ref=5b7005f"
 
   region                  = var.region
   environment             = var.environment
@@ -135,7 +134,7 @@ module "sat" {
 
 
 module "pv" {
-  source = "../../modules/services/pv"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/pv?ref=5b7005f"
 
   region                  = var.region
   environment             = var.environment
@@ -150,7 +149,7 @@ module "pv" {
 }
 
 module "gsp" {
-  source = "../../modules/services/gsp"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/gsp?ref=5b7005f"
 
   region                  = var.region
   environment             = var.environment
@@ -162,7 +161,7 @@ module "gsp" {
 }
 
 module "metrics" {
-  source = "../../modules/services/metrics"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/metrics?ref=5b7005f"
 
   region                  = var.region
   environment             = var.environment
@@ -175,7 +174,7 @@ module "metrics" {
 
 
 module "forecast" {
-  source = "../../modules/services/forecast"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/forecast?ref=5b7005f"
 
   region                        = var.region
   environment                   = var.environment
@@ -196,7 +195,7 @@ module "forecast" {
 
 
 module "national_forecast" {
-  source = "../../modules/services/forecast_generic"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/forecast_generic?ref=5b7005f"
 
   region      = var.region
   environment = var.environment
@@ -228,7 +227,7 @@ module "national_forecast" {
 }
 
 module "internal_ui" {
-    source = "../../modules/services/internal_ui"
+    source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/internal_ui?ref=5b7005f"
 
     region      = var.region
     environment = var.environment

--- a/terraform/pvsite/production/main.tf
+++ b/terraform/pvsite/production/main.tf
@@ -5,7 +5,7 @@ locals {
 }
 
 module "pvsite_subnetworking" {
-  source = "../../modules/subnetworking"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/subnetworking?ref=5b7005f"
 
   region                     = var.region
   environment                = var.environment
@@ -18,7 +18,7 @@ module "pvsite_subnetworking" {
 }
 
 module "pvsite_database" {
-  source = "../../modules/storage/postgres"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/storage/postgres?ref=5b7005f"
 
   region             = var.region
   environment        = var.environment
@@ -30,7 +30,7 @@ module "pvsite_database" {
 }
 
 module "pvsite_api" {
-  source = "../../modules/services/api_pvsite"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/api_pvsite?ref=5b7005f"
 
   region                          = var.region
   environment                     = var.environment
@@ -46,7 +46,7 @@ module "pvsite_api" {
 }
 
 module "pvsite_ml_bucket" {
-  source = "../../modules/storage/s3-private"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/storage/s3-private?ref=5b7005f"
 
   region              = var.region
   environment         = var.environment
@@ -56,7 +56,7 @@ module "pvsite_ml_bucket" {
 }
 
 module "pvsite_ecs" {
-  source = "../../modules/ecs"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/ecs?ref=5b7005f"
 
   region      = var.region
   environment = var.environment
@@ -64,7 +64,7 @@ module "pvsite_ecs" {
 }
 
 module "pvsite_forecast" {
-  source = "../../modules/services/forecast_generic"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/forecast_generic?ref=5b7005f"
 
   region      = var.region
   environment = var.environment


### PR DESCRIPTION
## Overview of the problem

Currently we are implementing two instances of dev/prod environment separation: in directory structure, and in branch. Whilst this is backed up by valid reasoning, it results in a lack of immediate clarity around the real source of truth for our TF instances, for instance:

- To see what's actively deployed in AWS development, does you look in `development/main.tf` on the main branch or the development branch?
- How do you quickly tell what changes in the development branch are present in main if the commit histories never line up?

## Why double up on the environment seperation methods?

### Directory-based seperation

The directory-based separation has a clear logical reasoning: by having a `development/main.tf` and a `production/main.tf` we are able to deploy different services to our production and development environments. This is important for being able to spin up environment-specific services, as well as testing services in the development environment prior to propagating through to production.

### Branch-based separation

The branch-based separation is a little more nuanced - it protects against deploying immediate module changes to production: since the `production/main.tf` and `development/main.tf` specify the same source for their modules (namely a local path `../../modules`), making a change to a module affects both environments. Therefore, being able to make that module change only on the dev branch first stops it from affecting the production service until the development branch is merged into main.

<details><summary>Is this protection necessary at all?</summary>
It could be argued this protection is not actually necessary in the first place, since no terraform runs are automatically applied from this repo. As such no change made in the repo will affect the deployed infrastructure without the manual intervention step of applying the terraform run, so module changes could propagate into production unless done purposefully.

However, I think it is still useful to have this protection in place as it removes any chances of accidental module deployment. Also, with this protection, we could then in good conscience enable automatic run applying in terraform which would streamline the deployment process.
</details>

## How does this PR remove the need for the branch-based separation whilst affording the same protections?

Instead of a devlopment branch, this PR proposes versioning the modules used in the `production/main.tf` via pinning them to specific commits in main. In this manner, modules sources in `development/main.tf` remain

```tf
# development/main.tf

module "my-module" {
  source = "../../modules/my-module
}
```

whilst modules in `production/main.tf` go to 

```tf
# production/main.tf

module "my-module" {
  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/my-module?ref=<COMMIT_SHA>
}
```

In this manner, modifying a module will only immedately affect usage in development, since that sources from files as they are currently on local filesystem. The workflow goes from

1. Create feature branch off development branch to make modifications to the module
2. PR back into development updates the deployed service in development
3. PR from development into main updates the deployed service in production (but may also update other, as yet unmerged changes in the development branch that are not present in the main branch)

to

1. Create feature branch off main branch to make modifications to the module
2. PR back into main updates the deployed service in development
3. Create update branch off main branch changing the version of the module used in `production/main.tf` to refer to the commit SHA of the feature branch PR commit
4. PR back into main updates the deployed service in production

The number of steps increases by one, but the benefit from this cost is the commit history of main now paints a clear and readable history of the state of the infrastructure, e.g.

```shell
95d3758 Update README.md
f465e29 Update new-service-1 in production to module version ca67db4 (#303) <-- Deploys to prod, single-commit PR
ca67db4 Modify new-service-1 module in `/modules` (#302) <-- Deploys to Dev, squashed PR
792cfa7 Add new-service-1 to `production/main.tf` (#301) <-- Deploys to Prod, single-commit PR
4a53d90 Add new-service-1 to `development/main.tf` and create new-service-1 module to `/modules` (#300) <-- Deploys to Dev, squashed PR
367d936 ...
```

Main can then become a write-protected branch as everything can be implemented using clear PRs to it. Nothing that is broken will end up in live due to the speculative plans that occur on every PR.

## External requirements

The VSC settings in Terraform cloud will need to be updated from looking at `development` and `main` branches, to just looking at `main`.

This change will need to get merged into `main` before the development branch can be deleted.
