### PR TITLE
add AUTH0_RULE_NAMESPACE to API

### DIFF
--- a/terraform/modules/services/api/eb.tf
+++ b/terraform/modules/services/api/eb.tf
@@ -61,6 +61,12 @@ resource "aws_elastic_beanstalk_environment" "eb-api-env" {
 
   setting {
     namespace = "aws:elasticbeanstalk:application:environment"
+    name      = "AUTH0_RULE_NAMESPACE"
+    value     = "https://openclimatefix.org"
+  }
+
+    setting {
+    namespace = "aws:elasticbeanstalk:application:environment"
     name      = "ORIGINS"
     value     = "*" #TODO change
   }


### PR DESCRIPTION
# Pull Request

## Description

Add a env varible to the API, this allows api request and users, to be logged to the database

related to https://github.com/openclimatefix/nowcasting_api/pull/215

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
