### PR TITLE
update PV Consumer time to run 1 minute earlier

### DIFF
--- a/terraform/modules/services/pv/schedule.tf
+++ b/terraform/modules/services/pv/schedule.tf
@@ -4,8 +4,8 @@
 
 resource "aws_cloudwatch_event_rule" "event_rule" {
   name                = "pv-schedule-${var.environment}"
-  schedule_expression = "cron(*/5 * * * ? *)"
-  # runs every 5 minutes
+  schedule_expression = "cron(4,9,14,19,24,29,34,39,44,49,54,59 * * * ? *)"
+  # runs every 5 minutes, with 1 minute buffer to start the ECS task
 }
 
 resource "aws_cloudwatch_event_target" "ecs_scheduled_task" {


### PR DESCRIPTION
# Pull Request

## Description

Update PV Consumer to run 1 minute earlier

Helps fix https://github.com/openclimatefix/nowcasting_forecast/issues/199

## How Has This Been Tested?

CI terrafrom tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
