### PR TITLE
ad option for loglevel in forecast generic

### DIFF
--- a/terraform/modules/services/forecast_generic/ecs.tf
+++ b/terraform/modules/services/forecast_generic/ecs.tf
@@ -27,7 +27,7 @@ resource "aws_ecs_task_definition" "ecs-task-definition" {
       essential = true
 
       environment : [
-        {"name": "LOGLEVEL", "value" : "DEBUG"},
+        {"name": "LOGLEVEL", "value" : var.loglevel},
         {"name": "NWP_ZARR_PATH", "value":"s3://${var.s3_nwp_bucket.bucket_id}/${var.s3_nwp_bucket.datadir}/latest.zarr"},
         {"name": "SATELLITE_ZARR_PATH", "value":"s3://${var.s3_satellite_bucket.bucket_id}/${var.s3_satellite_bucket.datadir}/latest.zarr.zip"},
         {"name": "ML_MODEL_PATH", "value": "s3://${var.s3_ml_bucket.bucket_id}/"},

--- a/terraform/modules/services/forecast_generic/variables.tf
+++ b/terraform/modules/services/forecast_generic/variables.tf
@@ -110,3 +110,9 @@ variable "s3_ml_bucket" {
 locals {
   log-group-name = "/aws/ecs/${var.app-name}/"
 }
+
+variable "loglevel" = {
+  type        = string
+  description = "The log level"
+  default     = "DEBUG"
+}

--- a/terraform/modules/services/forecast_generic/variables.tf
+++ b/terraform/modules/services/forecast_generic/variables.tf
@@ -111,7 +111,7 @@ locals {
   log-group-name = "/aws/ecs/${var.app-name}/"
 }
 
-variable "loglevel" = {
+variable "loglevel" {
   type        = string
   description = "The log level"
   default     = "DEBUG"

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -260,7 +260,7 @@ module "forecast_pvnet" {
     bucket_read_policy_arn = module.s3.iam-policy-s3-sat-read.arn
     datadir = "data/latest"
   }
-  loglebel= "INFO"
+  loglevel= "INFO"
 
 }
 

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -260,6 +260,7 @@ module "forecast_pvnet" {
     bucket_read_policy_arn = module.s3.iam-policy-s3-sat-read.arn
     datadir = "data/latest"
   }
+  loglebel= "INFO"
 
 }
 


### PR DESCRIPTION
# Pull Request

## Description

- change pvnet 2.0 to log level to INFO

## How Has This Been Tested?

CI terraform checks

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
