### PR TITLE
change site to 25 hours, so site db clean up works

### DIFF
--- a/terraform/modules/services/airflow/dags/forecast-site-dag.py
+++ b/terraform/modules/services/airflow/dags/forecast-site-dag.py
@@ -9,7 +9,7 @@ from airflow.operators.latest_only import LatestOnlyOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=0.5),
+    'start_date': datetime.utcnow() - timedelta(hours=25),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,


### PR DESCRIPTION
# Pull Request

## Description

change site level dag to look 25 hours in the past. This means the site db clean up will run

## How Has This Been Tested?

CI tests, similar to other dags with 24 hours
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
