### PR TITLE
Set backup_retention_period to 7 days to enable automated backups

### DIFF
--- a/terraform/modules/storage/database-pair/rds.tf
+++ b/terraform/modules/storage/database-pair/rds.tf
@@ -15,6 +15,7 @@ resource "aws_db_instance" "db-forecast" {
   vpc_security_group_ids       = [aws_security_group.rds-postgres-sg.id]
   ca_cert_identifier           = "rds-ca-2019"
   backup_window                = "00:00-00:30"
+  backup_retention_period      = 7
   db_subnet_group_name         = var.db_subnet_group.name # update name with private/public
   auto_minor_version_upgrade   = true
   performance_insights_enabled = true
@@ -45,6 +46,7 @@ resource "aws_db_instance" "db-pv" {
   vpc_security_group_ids       = [aws_security_group.rds-postgres-sg.id]
   ca_cert_identifier           = "rds-ca-2019"
   backup_window                = "00:00-00:30"
+  backup_retention_period      = 7
   db_subnet_group_name         = var.db_subnet_group.name # update name with private/public
   auto_minor_version_upgrade   = true
   performance_insights_enabled = true

--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -14,8 +14,9 @@ resource "aws_db_instance" "postgres-db" {
   publicly_accessible          = false
   vpc_security_group_ids       = [aws_security_group.rds-postgres-sg.id]
   ca_cert_identifier           = "rds-ca-2019"
-  backup_window                = "00:00-00:30"
   db_subnet_group_name         = var.db_subnet_group.name # update name with private/public
+  backup_window                = "00:00-00:30"
+  backup_retention_period      = 7
   auto_minor_version_upgrade   = true
   performance_insights_enabled = true
   allow_major_version_upgrade  = var.allow_major_version_upgrade


### PR DESCRIPTION
**Feature: Enable Automated Backups for RDS Instance**

This pull request adds functionality to enable automated backups for the RDS instance using Terraform. Automated backups are essential for data recovery and disaster resilience.

**Changes Made:**
- Introduced the 'backup_retention_period' attribute within the aws_db_instance resource block.
- Configured backup retention period to 7 days for ensuring adequate data retention.

**Why this is needed:**
Automated backups provide a safety net against data loss and system failures. This enhancement improves our infrastructure's reliability and resilience.

**Additional Notes:**
- Tested locally and verified proper integration with existing configurations.
- Documentation has been updated to reflect the new configuration option.

Fixes #90 