### PR TITLE
move airflow to nowcasting

### DIFF
--- a/terraform/airflow/development/main.tf
+++ b/terraform/airflow/development/main.tf
@@ -22,14 +22,3 @@ module "airflow_subnetworking" {
   public_internet_gateway_id = var.public_internet_gateway_id
 }
 
-module "airflow" {
-  source = "../../modules/services/airflow"
-
-  environment   = var.environment
-  vpc_id        = var.vpc_id
-  subnets       = [module.airflow_subnetworking.public_subnet.id]
-  db_url        = var.db_url
-  docker-compose-version       = "0.0.3"
-  ecs_subnet=module.airflow_subnetworking.public_subnet.id
-  ecs_security_group=var.ecs_security_group
-}

--- a/terraform/nowcasting/development/variables.tf
+++ b/terraform/nowcasting/development/variables.tf
@@ -100,3 +100,8 @@ variable "forecast_pvnet_version" {
 variable "forecast_blend_version" {
   description = "The Forecast Blend docker version"
 }
+
+variable "ecs_security_group" {
+  description = "The security group for airflow ecs tasks. TODO remove this"
+  type = string
+}


### PR DESCRIPTION
# Pull Request

## Description

Move airflow over to nowcasting platform
I left a TODO because I didnt want to change the actual airflow module

Note a new password would get made, so we would have to update where this is stored

Needed to add `ecs_security_group` to variables

Helps with #302 

## How Has This Been Tested?

Terraform run on CI

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
