### PR TITLE
add env variable for pvnet. This is needed when importing

### DIFF
--- a/terraform/modules/services/forecast_generic/ecs.tf
+++ b/terraform/modules/services/forecast_generic/ecs.tf
@@ -35,6 +35,7 @@ resource "aws_ecs_task_definition" "ecs-task-definition" {
         {"name": "OCF_ENVIRONMENT", "value": var.environment},
         {"name": "USE_ADJUSTER", "value": var.use_adjuster},
         {"name": "SAVE_GSP_SUM", "value": var.pvnet_gsp_sum},
+        {"name": "ESMFMKFILE",  "value": "/opt/conda/lib/esmf.mk"}
       ]
 
       secrets : [


### PR DESCRIPTION
# Pull Request

## Description

add env var to forecast generic, this is needed for pvnet when regridding the data

[Fixes #](https://github.com/openclimatefix/ocf-infrastructure/issues/320)

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
