### PR TITLE
Import restored pvsite database

### DIFF
--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -6,7 +6,7 @@ resource "aws_db_instance" "postgres-db" {
   engine                       = "postgres"
   engine_version               = "15.2"
   instance_class               = var.rds_instance_class
-  db_name                      = "${var.db_name}${var.environment}"
+  db_name                      = "${trim(var.db_name, "-")}${var.environment}"
   identifier                   = "${var.db_name}-${var.environment}"
   username                     = "main"
   password                     = random_password.db-password.result

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -423,9 +423,14 @@ module "pvsite_database" {
   environment                 = local.environment
   db_subnet_group_name        = module.networking.private_subnet_group_name
   vpc_id                      = module.networking.vpc_id
-  db_name                     = "pvsite"
+  db_name                     = "pv-sites"
   rds_instance_class          = "db.t3.small"
   allow_major_version_upgrade = true
+}
+
+import {
+  to = module.pvsite_database.aws_db_instance.postgres-db
+  id = "pv-sites-development"
 }
 
 import {


### PR DESCRIPTION
Having recreated the pvsite database from a copied snapshot of the prod database, this MR imports that database into the terraform state.