### PR TITLE
add airflow intergation to slack

### DIFF
--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -416,7 +416,7 @@ module "forecast_blend" {
 
 # 5.2
 module "airflow" {
-  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/airflow?ref=bd819f8"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/airflow?ref=ae1ebf9"
 
   environment   = local.environment
   vpc_id        = module.networking.vpc_id
@@ -426,6 +426,7 @@ module "airflow" {
   ecs_subnet_id = module.networking.public_subnet_ids[0]
   ecs_security_group=module.networking.default_security_group_id
   secretsmanager_arn = regex("^(.+):secret:", module.database.forecast-database-secret.arn)[0]
+  airflow_conn_slack_api_default=var.airflow_conn_slack_api_default
 }
 
 # 6.1

--- a/terraform/nowcasting/production/variables.tf
+++ b/terraform/nowcasting/production/variables.tf
@@ -100,3 +100,9 @@ variable "database_cleanup_version" {
   type = string
   description = "The version of the database clean up to use"
 }
+
+variable "airflow_conn_slack_api_default" {
+  type = string
+  description = "The slack connection string for airflow"
+  default = "not-set"
+}


### PR DESCRIPTION
# Pull Request

## Description

- add airflow intergration to slack
- add variable `airflow_conn_slack_api_default` to production terraform
- add env var to airflow instance
- adjutsed dags to send message on failure

Fixes #350 

![Screenshot 2023-11-23 at 10 42 27](https://github.com/openclimatefix/ocf-infrastructure/assets/34686298/e9917ad0-381d-49f3-99a1-6c1ca99721ce)


## How Has This Been Tested?

tested this on dev

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
