### PR TITLE
update dags task ids for forecast

### DIFF
--- a/terraform/modules/services/airflow/dags/forecast-gsp-dag.py
+++ b/terraform/modules/services/airflow/dags/forecast-gsp-dag.py
@@ -48,7 +48,7 @@ with DAG('gsp-forecast-pvnet-1', schedule_interval="15 */4 * * *", default_args=
     )
 
     forecast_blend = EcsRunTaskOperator(
-        task_id='forecast-blend',
+        task_id='forecast-blend-pvnet-1',
         task_definition="forecast_blend",
         cluster=cluster,
         overrides={},
@@ -73,7 +73,7 @@ with DAG('gsp-forecast-pvnet-2', schedule_interval="15,45 * * * *", default_args
     latest_only = LatestOnlyOperator(task_id="latest_only")
 
     forecast = EcsRunTaskOperator(
-        task_id='gsp-forecast-pvnet-1',
+        task_id='gsp-forecast-pvnet-2',
         task_definition="forecast_pvnet",
         cluster=cluster,
         overrides={},
@@ -90,7 +90,7 @@ with DAG('gsp-forecast-pvnet-2', schedule_interval="15,45 * * * *", default_args
     )
 
     forecast_blend = EcsRunTaskOperator(
-        task_id='forecast-blend',
+        task_id='forecast-blend-pvnet-2',
         task_definition="forecast_blend",
         cluster=cluster,
         overrides={},

--- a/terraform/modules/services/airflow/dags/forecast-national-dag.py
+++ b/terraform/modules/services/airflow/dags/forecast-national-dag.py
@@ -48,7 +48,7 @@ with DAG('national-forecast', schedule_interval="15,45 * * * *", default_args=de
     )
 
     forecast_blend = EcsRunTaskOperator(
-        task_id='forecast-blend',
+        task_id='forecast-blend-national-xg',
         task_definition="forecast_blend",
         cluster=cluster,
         overrides={},


### PR DESCRIPTION
# Pull Request

## Description

Update dags task-ids for forecast
Fix pvnet-2 task id name (it was labelled as pvnet 1)

## How Has This Been Tested?

CI tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
