### PR TITLE
retry national forecast 2

### DIFF
--- a/terraform/modules/services/airflow/dags/forecast-national-dag.py
+++ b/terraform/modules/services/airflow/dags/forecast-national-dag.py
@@ -10,7 +10,7 @@ default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
     'start_date': datetime.utcnow() - timedelta(hours=0.5),
-    'retries': 1,
+    'retries': 2,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,
     'concurrency':10,


### PR DESCRIPTION
# Pull Request

## Description

increase national forecast to 2 retries. This cover the bug that the nwp data is being made at the same time

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
