### PR TITLE
Fixes terraform depreciation on vpc -> domain #421

### DIFF
--- a/terraform/modules/networking/ec2_bastion/ec2.tf
+++ b/terraform/modules/networking/ec2_bastion/ec2.tf
@@ -28,5 +28,5 @@ resource "aws_instance" "ec2-bastion" {
 
 resource "aws_eip" "ip-bastion" {
   instance = aws_instance.ec2-bastion.id
-  vpc      = true
+  domain   = "vpc"
 }

--- a/terraform/modules/storage/postgres/rds.tf
+++ b/terraform/modules/storage/postgres/rds.tf
@@ -4,7 +4,7 @@ resource "aws_db_instance" "postgres-db" {
   allocated_storage            = 25
   max_allocated_storage        = 200
   engine                       = "postgres"
-  engine_version               = "15.5"
+  engine_version               = "16.1"
   instance_class               = var.rds_instance_class
   db_name                      = "${var.db_name}${var.environment}"
   identifier                   = "${var.db_name}-${var.environment}"


### PR DESCRIPTION
# Pull Request

## Description

This pull request to address a deprecation warning related to the usage of the vpc attribute in the aws_eip resource, the warning suggests using the domain attribute instead.

**Changes Made:**

- Replaced _vpc = "true"_ in _aws_eip_ resource, using _domain = "vpc"_


**Why this is needed:**

The pull request aims to update the Terraform code to align with the latest recommendations and resolve the deprecation warning.

Please review the changes, and if everything looks good, feel free to merge it. If you have any questions or concerns, please don't hesitate to reach out.

Thanks,
Pedro

Fixes #421 

## Checklist:

- [*] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [*] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [*] I have checked my code and corrected any misspellings