### PR TITLE
chore: renaming nwp service to include metoffice

### DIFF
--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -132,10 +132,10 @@ import {
 
 
 # 3.2
-module "nwp-national" {
+module "nwp-metoffice" {
   source = "../../modules/services/nwp_consumer"
 
-  ecs-task_name = "nwp-national"
+  ecs-task_name = "nwp-metoffice"
   ecs-task_type = "consumer"
   ecs-task_execution_role_arn = module.ecs.ecs_task_execution_role_arn
   ecs-task_size = {
@@ -168,7 +168,7 @@ module "nwp-national" {
     "--source=metoffice",
     "--sink=s3",
     "--rdir=raw-national",
-    "--zdir=data-national",
+    "--zdir=data-metoffice",
     "--create-latest"
   ]
 }
@@ -294,7 +294,7 @@ module "national_forecast" {
   s3_nwp_bucket = {
     bucket_id              = module.s3.s3-nwp-bucket.id
     bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn
-    datadir                = "data-national"
+    datadir                = "data-metoffice"
   }
 }
 
@@ -322,7 +322,7 @@ module "forecast_pvnet" {
   s3_nwp_bucket = {
     bucket_id              = module.s3.s3-nwp-bucket.id
     bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn
-    datadir                = "data-national"
+    datadir                = "data-metoffice"
   }
   s3_satellite_bucket = {
     bucket_id              = module.s3.s3-sat-bucket.id
@@ -472,7 +472,7 @@ module "pvsite_forecast" {
   s3_nwp_bucket = {
     bucket_id              = module.s3.s3-nwp-bucket.id
     bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn
-    datadir                = "data-national"
+    datadir                = "data-metoffice"
   }
   ecs-task_execution_role_arn = module.ecs.ecs_task_execution_role_arn
 }


### PR DESCRIPTION
# Pull Request

## Description

This PR resolves https://github.com/openclimatefix/ocf-infrastructure/issues/469
In the `nowcasting/development/main.tf` file, I have made changes to the `nwp-national` and `data-national` service as instructed in the issue

Fixes #

## How Has This Been Tested?

I was not able to `terraform validate` to run the tests, if possible can someone guide me a bit more on how to run the tests

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
