### PR TITLE
added timezone aware datetime function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ terraform.rc
 .vscode
 .fleet
 .DS_Store
+venv

--- a/terraform/modules/services/airflow/dags/india/forecast-site-dag.py
+++ b/terraform/modules/services/airflow/dags/india/forecast-site-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from utils.slack import on_failure_callback
@@ -9,7 +9,7 @@ from airflow.operators.latest_only import LatestOnlyOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=3),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=3),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,

--- a/terraform/modules/services/airflow/dags/india/nwp-dag.py
+++ b/terraform/modules/services/airflow/dags/india/nwp-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 
@@ -9,7 +9,7 @@ from utils.slack import on_failure_callback
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=1.5),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=1.5),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,

--- a/terraform/modules/services/airflow/dags/india/runvnl-data-dag.py
+++ b/terraform/modules/services/airflow/dags/india/runvnl-data-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from utils.slack import on_failure_callback
@@ -9,7 +9,7 @@ from airflow.operators.latest_only import LatestOnlyOperator
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime.utcnow() - timedelta(hours=2),
+    "start_date": datetime.now(tz=timezone.utc) - timedelta(hours=2),
     "retries": 1,
     "retry_delay": timedelta(minutes=1),
     "max_active_runs": 10,

--- a/terraform/modules/services/airflow/dags/uk/forecast-gsp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/forecast-gsp-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from utils.slack import on_failure_callback
@@ -9,7 +9,7 @@ from airflow.operators.latest_only import LatestOnlyOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=1.5),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=1.5),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,

--- a/terraform/modules/services/airflow/dags/uk/forecast-national-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/forecast-national-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 
@@ -9,7 +9,7 @@ from utils.slack import on_failure_callback
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=0.5),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=0.5),
     'retries': 2,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,

--- a/terraform/modules/services/airflow/dags/uk/forecast-site-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/forecast-site-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from utils.slack import on_failure_callback
@@ -9,7 +9,7 @@ from airflow.operators.latest_only import LatestOnlyOperator
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=25),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=25),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,

--- a/terraform/modules/services/airflow/dags/uk/gsp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/gsp-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 
@@ -9,7 +9,7 @@ from utils.slack import on_failure_callback
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=0.5),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=0.5),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs': 10,

--- a/terraform/modules/services/airflow/dags/uk/nwp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/nwp-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 
@@ -9,7 +9,7 @@ from utils.slack import on_failure_callback
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=0.5),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=0.5),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,

--- a/terraform/modules/services/airflow/dags/uk/pv-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/pv-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from airflow.decorators import dag
@@ -10,7 +10,7 @@ from utils.slack import on_failure_callback
 default_args = {
     'owner': 'airflow',
     'depends_on_past': False,
-    'start_date': datetime.utcnow() - timedelta(hours=0.5),
+    'start_date': datetime.now(tz=timezone.utc) - timedelta(hours=0.5),
     'retries': 1,
     'retry_delay': timedelta(minutes=1),
     'max_active_runs':10,

--- a/terraform/modules/services/airflow/dags/uk/satellite-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/satellite-dag.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from airflow.decorators import dag
@@ -33,7 +33,7 @@ with DAG(
     default_args=default_args,
     concurrency=10,
     max_active_tasks=10,
-    start_date=datetime.utcnow() - timedelta(hours=0.5),
+    start_date=datetime.now(tz=timezone.utc) - timedelta(hours=0.5),
 ) as dag:
     dag.doc_md = "Get Satellite data"
 
@@ -64,7 +64,7 @@ with DAG(
     default_args=default_args,
     concurrency=10,
     max_active_tasks=10,
-    start_date=datetime.utcnow() - timedelta(hours=7),
+    start_date=datetime.now(tz=timezone.utc) - timedelta(hours=7),
 ) as dag:
     dag.doc_md = "Satellite data clean up"
 


### PR DESCRIPTION
# Pull Request

## Description

the `datetime.utcnow()` method is considered deprecated in modern Python versions, and it's recommended to use the more explicit `datetime.now(tz=datetime.timezone.utc)` instead. The `utcnow()` method is still functional, but it's considered less clear and less timezone-aware than the alternative. I have thus replaced the deprecated method with the newer one

Fixes #

#528 

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
