### PR TITLE
add dags for updating data

### DIFF
--- a/terraform/modules/services/airflow/dags/uk/nwp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/nwp-dag.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
+from airflow.operators.bash import BashOperator
 
 from airflow.operators.latest_only import LatestOnlyOperator
 from utils.slack import on_failure_callback
@@ -25,6 +26,11 @@ cluster = f"Nowcasting-{env}"
 # Tasks can still be defined in terraform, or defined here
 
 region = 'uk'
+
+if env == 'development':
+    url = "http://api-dev.quartz.solar"
+else:
+    url = "http://api.quartz.solar"
 
 with DAG(f'{region}-nwp-consumer', schedule_interval="10,25,40,55 * * * *", default_args=default_args, concurrency=10, max_active_tasks=10) as dag:
     dag.doc_md = "Get NWP data"
@@ -64,6 +70,20 @@ with DAG(f'{region}-nwp-consumer', schedule_interval="10,25,40,55 * * * *", defa
         task_concurrency=10,
     )
 
-    latest_only >> nwp_national_consumer
-    latest_only >> nwp_ecmwf_consumer
+    file = f's3://nowcasting-nwp-{env}/data-national/latest.zarr.zip'
+    command = f'curl -X GET {url}/v0/solar/GB/update_last_data?component=nwp&file={file}'
+    nwp_update_ukv = BashOperator(
+        task_id="nwp-update-ukv",
+        bash_command=command,
+    )
+
+    file = f's3://nowcasting-nwp-{env}/ecmwf/data/latest.zarr.zip'
+    command = f'curl -X GET {url}/v0/solar/GB/update_last_data?component=nwp&file={file}'
+    nwp_update_ecmwf = BashOperator(
+        task_id="nwp-update-ecmwf",
+        bash_command=command,
+    )
+
+    latest_only >> nwp_national_consumer >> nwp_update_ukv
+    latest_only >> nwp_ecmwf_consumer >> nwp_update_ecmwf
 

--- a/terraform/modules/services/airflow/dags/uk/satellite-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/satellite-dag.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
 from airflow.decorators import dag
+from airflow.operators.bash import BashOperator
 
 from airflow.operators.latest_only import LatestOnlyOperator
 from utils.slack import on_failure_callback
@@ -26,6 +27,11 @@ cluster = f"Nowcasting-{env}"
 # Tasks can still be defined in terraform, or defined here
 
 region = 'uk'
+
+if env == 'development':
+    url = "http://api-dev.quartz.solar"
+else:
+    url = "http://api.quartz.solar"
 
 with DAG(
     f'{region}-national-satellite-consumer',
@@ -56,7 +62,14 @@ with DAG(
         on_failure_callback=on_failure_callback
     )
 
-    latest_only >> sat_consumer
+    file = f's3://nowcasting-sat-{env}/ecmwf/data/latest/latest.zarr.zip'
+    command = f'curl -X GET {url}/v0/solar/GB/update_last_data?component=satellite&file={file}'
+    satellite_update = BashOperator(
+        task_id=f"{region}-satellite-update",
+        bash_command=command,
+    )
+
+    latest_only >> sat_consumer >> satellite_update
 
 with DAG(
     f'{region}-national-satellite-cleanup',


### PR DESCRIPTION
# Pull Request

## Description

Add bash operater to hit api after consumer has finished. This is for
- gsp
- nwp
- satellite

Helps with https://github.com/openclimatefix/uk-pv-national-gsp-api/issues/337

## How Has This Been Tested?

Deploy one of the dags manually and checked it worked

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
