### PR TITLE
upgrade airflow, give api acess to nwp and sat buckets

### DIFF
--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -83,7 +83,7 @@ module "forecasting_models_bucket" {
 
 # 1.1
 module "api" {
-  source             = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/eb_app?ref=6e24edf"
+  source             = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/eb_app?ref=72ba38d"
   domain             = local.domain
   aws-region         = var.region
   aws-environment    = local.environment
@@ -106,6 +106,10 @@ module "api" {
   container-registry = "openclimatefix"
   eb-app_name    = "nowcasting-api"
   eb-instance_type = "t3.small"
+  s3_bucket = [
+    { bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn },
+    { bucket_read_policy_arn = module.s3.iam-policy-s3-sat-read.arn }
+  ]
 }
 
 # 2.1
@@ -397,7 +401,7 @@ module "forecast_blend" {
 
 # 5.2
 module "airflow" {
-  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/airflow?ref=e4534fb"
+  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/airflow?ref=72ba38d"
 
   aws-environment   = local.environment
   aws-domain        = local.domain


### PR DESCRIPTION
# Pull Request

## Description

Upgrade airflow, so dags hit api endpoint when nwp, sat, and gsp consumer are complete
Give API read access to s3 buckets

[Fixes #](https://github.com/openclimatefix/uk-pv-national-gsp-api/issues/337)

## How Has This Been Tested?

Tested on dev

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
