### PR TITLE
remove region from national-dag-after #541

### DIFF
--- a/terraform/modules/services/airflow/dags/uk/dayafter-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/dayafter-dag.py
@@ -38,7 +38,7 @@ with DAG(
 
     national_day_after = EcsRunTaskOperator(
         task_id=f'{region}-national-day-after',
-        task_definition=f'{region}-national-day-after',
+        task_definition='national-day-after',
         cluster=cluster,
         overrides={},
         awslogs_region="eu-west-1",


### PR DESCRIPTION
# Pull Request

## Description

Update so that `national-dag-after` doesnt have `region` in it
Fixes #541 

## How Has This Been Tested?

All other dags work liek this

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
