### PR TITLE
fix(ecs-task): Enable specification of ephemeral storage size

### DIFF
--- a/terraform/india/development/main.tf
+++ b/terraform/india/development/main.tf
@@ -175,6 +175,7 @@ module "ruvnl_consumer_ecs" {
   ecs-task_size = {
     memory = 512
     cpu    = 256
+    storage = 21
   }
 
   s3-buckets = []

--- a/terraform/india/development/main.tf
+++ b/terraform/india/development/main.tf
@@ -7,7 +7,7 @@
 # 2.0 - S3 bucket for NWP data
 # 3.0 - Secret containing environment variables for the NWP consumer
 # 3.1 - ECS task definition for the NWP consumer
-# 3.2 - ECS task definition for the Meteomatics consumer
+# 3.2 - ECS task definition for the GFS consumer
 # 3.3 - ECS task definition for Collection RUVNL data
 # 3.4 - ECS task definition for the Forecast
 # 4.0 - Airflow EB Instance
@@ -117,47 +117,16 @@ module "nwp_consumer_ecmwf_live_ecs_task" {
 }
 
 # 3.2
-module "nwp_consumer_meteomatics_live_ecs_task" {
-  source = "../../modules/services/ecs_task"
-
-  ecs-task_name               = "nwp-consumer-meteomatics-india"
-  ecs-task_type               = "consumer"
-  ecs-task_execution_role_arn = module.ecs-cluster.ecs_task_execution_role_arn
-
-  aws-region                    = var.region
-  aws-environment               = local.environment
-  aws-secretsmanager_secret_arn = aws_secretsmanager_secret.nwp_consumer_secret.arn
-
-  s3-buckets = [
-    {
-      id : module.s3-nwp-bucket.bucket_id,
-      access_policy_arn : module.s3-nwp-bucket.write_policy_arn
-    }
-  ]
-
-  container-env_vars = [
-    { "name" : "AWS_REGION", "value" : var.region },
-    { "name" : "AWS_S3_BUCKET", "value" : module.s3-nwp-bucket.bucket_id },
-    { "name" : "LOGLEVEL", "value" : "DEBUG" },
-  ]
-  container-secret_vars = ["METEOMATICS_USERNAME", "METEOMATICS_PASSWORD"]
-  container-tag         = var.version-nwp
-  container-name        = "openclimatefix/nwp-consumer"
-  container-command     = [
-    "download",
-    "--source=meteomatics",
-    "--sink=s3",
-    "--rdir=meteomatics/raw",
-    "--zdir=meteomatics/data",
-    "--create-latest"
-  ]
-}
-
 module "nwp_consumer_gfs_live_ecs_task" {
   source = "../../modules/services/ecs_task"
 
   ecs-task_name               = "nwp-consumer-gfs-india"
   ecs-task_type               = "consumer"
+  ecs-task_size = {
+    cpu    = 1024
+    memory = 5120
+    storage = 40
+  }
   ecs-task_execution_role_arn = module.ecs-cluster.ecs_task_execution_role_arn
 
   aws-region                    = var.region

--- a/terraform/modules/services/ecs_task/ecs.tf
+++ b/terraform/modules/services/ecs_task/ecs.tf
@@ -18,8 +18,8 @@ resource "aws_ecs_task_definition" "task_def" {
   volume {
     name = "${var.ecs-task_name}-temp-data"
     docker_volume_configuration {
-      scope = "task",
-      driver = "local",
+      scope = "task"
+      driver = "local"
     }
   }
 

--- a/terraform/modules/services/ecs_task/ecs.tf
+++ b/terraform/modules/services/ecs_task/ecs.tf
@@ -16,7 +16,7 @@ resource "aws_ecs_task_definition" "task_def" {
   }
 
   volume {
-    name = "${var.ecs-task_name}-temp-data",
+    name = "${var.ecs-task_name}-temp-data"
     docker_volume_configuration {
       scope = "task",
       driver = "local",

--- a/terraform/modules/services/ecs_task/ecs.tf
+++ b/terraform/modules/services/ecs_task/ecs.tf
@@ -16,7 +16,15 @@ resource "aws_ecs_task_definition" "task_def" {
   }
 
   volume {
-    name = "${var.ecs-task_name}-temp-data"
+    name = "${var.ecs-task_name}-temp-data",
+    docker_volume_configuration {
+      scope = "task",
+      driver = "local",
+    }
+  }
+
+  ephemeral_storage {
+    size_in_gib = var.ecs-task_size.storage
   }
 
   task_role_arn         = aws_iam_role.run_task_role.arn

--- a/terraform/modules/services/ecs_task/variables.tf
+++ b/terraform/modules/services/ecs_task/variables.tf
@@ -100,7 +100,7 @@ variable ecs-task_size {
       memory : "Memory units (MB) for the ECS task"
       storage : "Ephemeral storage (GB) for the ECS task"
     }
-    ecs-task_size: "Size of the ECS task in terms of compute, memory, and epehemral storage."
+    ecs-task_size: "Size of the ECS task in terms of compute, memory, and ephemeral storage."
   EOT
 
   default = {

--- a/terraform/modules/services/ecs_task/variables.tf
+++ b/terraform/modules/services/ecs_task/variables.tf
@@ -91,24 +91,27 @@ variable ecs-task_size {
   type = object({
     cpu = number
     memory = number
+    storage = number
   })
 
   description = <<EOT
     ecs-task_size = {
       cpu : "CPU units for the ECS task"
       memory : "Memory units (MB) for the ECS task"
+      storage : "Ephemeral storage (GB) for the ECS task"
     }
-    ecs-task_size: "Size of the ECS task in terms of compute and memory"
+    ecs-task_size: "Size of the ECS task in terms of compute, memory, and epehemral storage."
   EOT
 
   default = {
     cpu = 1024
     memory = 5120
+    storage = 21
   }
   
   validation {
-    condition = length(keys(var.ecs-task_size)) == 2
-    error_message = "Variable ecs-task_size must have exactly two keys: cpu and memory."
+    condition = length(keys(var.ecs-task_size)) == 3
+    error_message = "Variable ecs-task_size must have exactly three keys: cpu, memory, and storage."
   }
   validation {
     condition = contains([256, 512, 1024, 2048, 4096, 8192], var.ecs-task_size.cpu)
@@ -127,6 +130,14 @@ variable ecs-task_size {
       true
     )
     error_message = "Invalid combination of CPU and memory."
+  }
+  validation {
+    condition = var.ecs-task_size.storage >= 21
+    error_message = "Storage must be at least 21."
+  }
+  validation {
+    condition = var.ecs-task_size.storage <= 200
+    error_message = "Storage must be at most 200."
   }
 }
 

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -145,6 +145,7 @@ module "nwp-national" {
   ecs-task_size = {
     cpu    = 1024
     memory = 8192
+    storage = 21
   }
 
   aws-region                     = var.region
@@ -268,7 +269,11 @@ module "metrics" {
   ecs-task_execution_role_arn = module.ecs.ecs_task_execution_role_arn
   ecs-task_name = "metrics"
   ecs-task_type = "anaylsis"
-  ecs-task_size = {"cpu": 256, "memory": 512}
+  ecs-task_size = {
+    cpu = 256
+    memory = 512
+    storage = 21
+  }
 
   container-name = "openclimatefix/nowcasting_metrics"
   container-tag = var.metrics_version

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -268,7 +268,7 @@ module "metrics" {
 
   ecs-task_execution_role_arn = module.ecs.ecs_task_execution_role_arn
   ecs-task_name = "metrics"
-  ecs-task_type = "anaylsis"
+  ecs-task_type = "analysis"
   ecs-task_size = {
     cpu = 256
     memory = 512


### PR DESCRIPTION
GFS container runs out of disk space. This enables it to be specified.