### PR TITLE
change to run india foercast at 15 minutes past

### DIFF
--- a/terraform/modules/services/airflow/dags/india/forecast-site-dag.py
+++ b/terraform/modules/services/airflow/dags/india/forecast-site-dag.py
@@ -24,7 +24,7 @@ cluster = f"india-ecs-cluster-{env}"
 
 region = 'india' 
 
-with DAG(f'{region}-runvl-forecast', schedule_interval="0 * * * *", default_args=default_args, concurrency=10, max_active_tasks=10) as dag:
+with DAG(f'{region}-runvl-forecast', schedule_interval="15 * * * *", default_args=default_args, concurrency=10, max_active_tasks=10) as dag:
     dag.doc_md = "Run the forecast"
 
     latest_only = LatestOnlyOperator(task_id="latest_only")


### PR DESCRIPTION
# Pull Request

## Description

- run forecast at 15 minutes past. This should mean the forecast doesnt fail at 08.00 and 20,00 every day

Fixes #

## How Has This Been Tested?

CI tests

- [ ] Yes


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
