### PR TITLE
add use data sampler to forecast generic

### DIFF
--- a/terraform/modules/services/forecast_generic/ecs.tf
+++ b/terraform/modules/services/forecast_generic/ecs.tf
@@ -43,6 +43,7 @@ resource "aws_ecs_task_definition" "ecs-task-definition" {
         {"name": "SENTRY_DSN",  "value": var.sentry_dsn},
         {"name": "RUN_EXTRA_MODELS",  "value": var.run_extra_models},
         {"name": "DAY_AHEAD_MODEL",  "value": var.day_ahead_model}
+        {"name": "USE_OCF_DATA_SAMPLER",  "value": var.use_data_sample}
       ]
 
       secrets : [

--- a/terraform/modules/services/forecast_generic/ecs.tf
+++ b/terraform/modules/services/forecast_generic/ecs.tf
@@ -42,8 +42,8 @@ resource "aws_ecs_task_definition" "ecs-task-definition" {
         {"name": "ESMFMKFILE",  "value": "/opt/conda/lib/esmf.mk"},
         {"name": "SENTRY_DSN",  "value": var.sentry_dsn},
         {"name": "RUN_EXTRA_MODELS",  "value": var.run_extra_models},
-        {"name": "DAY_AHEAD_MODEL",  "value": var.day_ahead_model}
-        {"name": "USE_OCF_DATA_SAMPLER",  "value": var.use_data_sample}
+        {"name": "DAY_AHEAD_MODEL",  "value": var.day_ahead_model},
+        {"name": "USE_OCF_DATA_SAMPLER",  "value": var.use_data_sample},
       ]
 
       secrets : [

--- a/terraform/modules/services/forecast_generic/variables.tf
+++ b/terraform/modules/services/forecast_generic/variables.tf
@@ -146,3 +146,9 @@ variable "day_ahead_model" {
   description = "Whether to run the day ahead model"
   default     = "false"
 }
+
+variable "use_data_sample" {
+  type        = string
+  description = "Whether to use-data-sampler or not"
+  default     = "false"
+}


### PR DESCRIPTION
# Pull Request

## Description

add use-data-sampler to forecast generic, set to default

## How Has This Been Tested?

CI tests
- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
