### PR TITLE
Add NWP_MO_GLOBAL_ZARR_PATH to forecast_generic

### DIFF
--- a/terraform/modules/services/forecast_generic/ecs.tf
+++ b/terraform/modules/services/forecast_generic/ecs.tf
@@ -32,6 +32,7 @@ resource "aws_ecs_task_definition" "ecs-task-definition" {
         {"name": "NWP_UKV_ZARR_PATH", "value":"s3://${var.s3_nwp_bucket.bucket_id}/${var.s3_nwp_bucket.datadir}/latest.zarr"},
         {"name": "NWP_ECMWF_ZARR_PATH", "value":"s3://${var.s3_nwp_bucket.bucket_id}/ecmwf/data/latest.zarr"},
         {"name": "NWP_GFS_ZARR_PATH", "value":"s3://${var.s3_nwp_bucket.bucket_id}/gfs/data/latest.zarr"},
+        {"name": "NWP_MO_GLOBAL_ZARR_PATH", "value": "s3://${var.s3_nwp_bucket.bucket_id}/metoffice/data/latest.zarr"},
         {"name": "SATELLITE_ZARR_PATH", "value":"s3://${var.s3_satellite_bucket.bucket_id}/${var.s3_satellite_bucket.datadir}/latest.zarr.zip"},
         {"name": "ML_MODEL_PATH", "value": "s3://${var.s3_ml_bucket.bucket_id}/"},
         {"name": "ML_MODEL_BUCKET", "value": var.s3_ml_bucket.bucket_id},


### PR DESCRIPTION
Fixes `KeyError: 'NWP_MO_GLOBAL_ZARR_PATH'` seen in cloudwatch.