### PR TITLE
use .zattrs when looking nwp has been updated

### DIFF
--- a/terraform/modules/services/airflow/dags/uk/nwp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/nwp-dag.py
@@ -75,14 +75,14 @@ with DAG(f'{region}-nwp-consumer', schedule_interval="10,25,40,55 * * * *", defa
         task_id="determine_latest_zarr_ecmwf",
     )(bucket=f'nowcasting-nwp-{env}', prefix='ecmwf/data')
 
-    file = f's3://nowcasting-nwp-{env}/data-metoffice/latest.zarr'
+    file = f's3://nowcasting-nwp-{env}/data-metoffice/latest.zarr/.zattrs'
     command = f'curl -X GET "{url}/v0/solar/GB/update_last_data?component=nwp&file={file}"'
     nwp_update_ukv = BashOperator(
         task_id="nwp-update-ukv",
         bash_command=command,
     )
 
-    file = f's3://nowcasting-nwp-{env}/ecmwf/data/latest.zarr'
+    file = f's3://nowcasting-nwp-{env}/ecmwf/data/latest.zarr/.zattrs'
     command = f'curl -X GET "{url}/v0/solar/GB/update_last_data?component=nwp&file={file}"'
     nwp_update_ecmwf = BashOperator(
         task_id="nwp-update-ecmwf",


### PR DESCRIPTION
# Pull Request

## Description

Look at .zattrs when looking at when the nwp was last updated

Fixes https://github.com/openclimatefix/ocf-infrastructure/issues/740

## How Has This Been Tested?

- [x] CI test
- [x] ran bash command locally

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
