### PR TITLE
spelling corrected for PVNet ECMWF

### DIFF
--- a/terraform/modules/services/airflow/dags/uk/forecast-gsp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/forecast-gsp-dag.py
@@ -50,7 +50,7 @@ with DAG(f'{region}-gsp-forecast-pvnet-2', schedule_interval="15,45 * * * *", de
     )
 
     forecast_ecmwf = EcsRunTaskOperator(
-        task_id=f'{region}-gsp-forecast-pvnet-2-ecwmf',
+        task_id=f'{region}-gsp-forecast-pvnet-2-ecmwf',
         task_definition='forecast_pvnet_ecmwf',
         cluster=cluster,
         overrides={},


### PR DESCRIPTION
Correct dag spelling for PVNet ECMWF
Helps [openclimatefix/ocf-infrastructure/issues/748]

Just a simple spelling fix.

@peterdudfield It seemed easy, so I am opening a PR. Let me know if any changes are required. Thanks. 
