### PR TITLE
add ecs task and dag for neso foreacst

### DIFF
--- a/terraform/modules/services/airflow/dags/uk/forecast-national-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/forecast-national-dag.py
@@ -89,7 +89,7 @@ with DAG(
     concurrency=10,
     max_active_tasks=10,
 ) as dag:
-    dag.doc_md = "Get PV data"
+    dag.doc_md = "Get NESO Solar forecast"
 
     latest_only = LatestOnlyOperator(task_id="latest_only")
 

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -21,6 +21,7 @@ The componentes ares:
 3.7 - PVLive Consumer (From PVLive)
 3.8 - PVLive Consumer - GSP Day After
 3.9 - PVLive Consumer - National Day After
+3.10 - NESO Forecast Consumer
 4.1 - Metrics
 4.2 - Forecast PVnet 1
 4.3 - Forecast National XG
@@ -468,6 +469,37 @@ module "gsp-consumer-day-after-national" {
   ]
   container-tag         = var.gsp_version
   container-name        = "openclimatefix/pvliveconsumer"
+  container-registry = "docker.io"
+  container-command     = []
+}
+
+# 3.10
+module "neso-forecast-consumer" {
+  source = "../../modules/services/ecs_task"
+
+  ecs-task_name = "neso-forecast"
+  ecs-task_type = "consumer"
+  ecs-task_execution_role_arn = module.ecs.ecs_task_execution_role_arn
+  ecs-task_size = {
+    cpu    = 256
+    memory = 512
+  }
+
+  aws-region                     = var.region
+  aws-environment                = local.environment
+
+  s3-buckets = []
+
+  container-env_vars = [
+    { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
+    { "name" : "ENVIRONMENT", "value" : local.environment },
+  ]
+  container-secret_vars = [
+  {secret_policy_arn: module.database.forecast-database-secret.arn,
+  values: ["DB_URL"]}
+  ]
+  container-tag         = var.neso_forecast_consumer_version
+  container-name        = "openclimatefix/neso_solar_consumer_api"
   container-registry = "docker.io"
   container-command     = []
 }

--- a/terraform/nowcasting/development/variables.tf
+++ b/terraform/nowcasting/development/variables.tf
@@ -127,5 +127,5 @@ variable "sentry_dsn_api" {
 variable "neso_forecast_consumer_version" {
   type        = string
   description = "The version of the neso forecast consumer"
-  default     = "1.0.2"
+  default     = "1.0.3"
 }

--- a/terraform/nowcasting/development/variables.tf
+++ b/terraform/nowcasting/development/variables.tf
@@ -123,3 +123,9 @@ variable "sentry_dsn_api" {
   description = "The Sentry DSN for all backend components"
   default     = ""
 }
+
+variable "neso_forecast_consumer_version" {
+  type        = string
+  description = "The version of the neso forecast consumer"
+  default     = "1.0.2"
+}


### PR DESCRIPTION
# Pull Request

## Description

- add ECS task for NESO solar forecast consumer
- add DAG to pull this data once an hour

#702 

Need https://github.com/openclimatefix/neso-solar-consumer/pull/33 before deploying
## How Has This Been Tested?

CI tests, 

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
