### PR TITLE
Set HISTORY=75 minutes for satellite forecast

### DIFF
--- a/terraform/india/production/main.tf
+++ b/terraform/india/production/main.tf
@@ -323,6 +323,7 @@ module "satellite_consumer_ecs" {
     { "name" : "SAVE_DIR_NATIVE", "value" : "s3://${module.s3-satellite-bucket.bucket_id}/raw" },
     { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
     { "name" : "ENVIRONMENT", "value" : local.environment },
+    { "name" : "HISTORY", "value" : "75 minutes" }
   ]
   container-secret_vars = ["API_KEY", "API_SECRET"]
   container-tag         = var.satellite-consumer


### PR DESCRIPTION
# Pull Request

## Description

Updated the HISTORY environment variable from 60 to 75 minutes for satellite forecasts.  

Fixes #772 

## How Has This Been Tested?

- [x] Verified Terraform changes with terraform validate  
- [x] Confirmed the environment variable update works correctly  

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
