### PR TITLE
change foreast_generic, on national-xg and pvsite forecast

### DIFF
--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -477,32 +477,49 @@ module "metrics" {
 
 # 4.3
 module "national_forecast" {
-  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/forecast_generic?ref=4d421e0"
+    source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/ecs_task?ref=244a67d"
 
-  region      = var.region
-  environment = local.environment
-  app-name    = "forecast_national"
-  ecs_config  = {
-    docker_image   = "openclimatefix/gradboost_pv"
-    docker_version = var.national_forecast_version
-    memory_mb      = 11264
-    cpu            = 2048
-  }
-  rds_config = {
-    database_secret_arn             = module.database.forecast-database-secret.arn
-    database_secret_read_policy_arn = module.database.iam-policy-forecast-db-read.arn
-  }
-  s3_ml_bucket = {
-    bucket_id              = module.forecasting_models_bucket.bucket_id
-    bucket_read_policy_arn = module.forecasting_models_bucket.read_policy_arn
-  }
-  s3_nwp_bucket = {
-    bucket_id              = module.s3.s3-nwp-bucket.id
-    bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn
-    datadir                = "data-metoffice"
-  }
+  aws-region                    = var.region
+  aws-environment               = local.environment
+
+  s3-buckets = [
+    {
+      id : module.s3.s3-nwp-bucket.id,
+      access_policy_arn : module.s3.iam-policy-s3-nwp-read.arn
+    },
+    {
+      id : module.forecasting_models_bucket.bucket_id,
+      access_policy_arn : module.forecasting_models_bucket.read_policy_arn
+    }
+  ]
+
+  ecs-task_name               = "forecast_national"
+  ecs-task_type               = "forecast"
   ecs-task_execution_role_arn = module.ecs.ecs_task_execution_role_arn
-  sentry_dsn = var.sentry_dsn
+  ecs-task_size = {
+    memory = 11264
+    cpu    = 2048
+  }
+
+  container-env_vars = [
+    { "name" : "AWS_REGION", "value" : var.region },
+    { "name" : "ENVIRONMENT", "value" : local.environment },
+    { "name" : "LOGLEVEL", "value" : "INFO" },
+    { "name" : "NWP_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr"},
+    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn},
+    { "name": "ML_MODEL_BUCKET", "value": module.forecasting_models_bucket.bucket_id}
+  ]
+
+  container-secret_vars = [
+       {secret_policy_arn: module.database.forecast-database-secret.arn,
+        values: ["DB_URL"]
+       }
+       ]
+
+  container-tag         = var.national_forecast_version
+  container-name        = "openclimatefix/gradboost_pv"
+  container-registry    = "docker.io"
+  container-command     = []
 }
 
 # 4.4
@@ -806,32 +823,48 @@ module "pvsite_ml_bucket" {
 
 # 6.4
 module "pvsite_forecast" {
-  source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/forecast_generic?ref=4d421e0"
+    source = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/ecs_task?ref=244a67d"
 
-  region      = var.region
-  environment = local.environment
-  app-name    = "pvsite_forecast"
-  ecs_config  = {
-    docker_image   = "openclimatefix/pvsite_forecast"
-    docker_version = var.pvsite_forecast_version
-    memory_mb      = 4096
-    cpu            = 1024
-  }
-  rds_config = {
-    database_secret_arn             = module.pvsite_database.secret.arn
-    database_secret_read_policy_arn = module.pvsite_database.secret-policy.arn
-  }
-  s3_ml_bucket = {
-    bucket_id              = module.pvsite_ml_bucket.bucket_id
-    bucket_read_policy_arn = module.pvsite_ml_bucket.read_policy_arn
-  }
-  s3_nwp_bucket = {
-    bucket_id              = module.s3.s3-nwp-bucket.id
-    bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn
-    datadir                = "data-metoffice"
-  }
+  aws-region                    = var.region
+  aws-environment               = local.environment
+
+  s3-buckets = [
+    {
+      id : module.s3.s3-nwp-bucket.id,
+      access_policy_arn : module.s3.iam-policy-s3-nwp-read.arn
+    },
+    {
+      id : module.pvsite_ml_bucket.bucket_id,
+      access_policy_arn : module.pvsite_ml_bucket.read_policy_arn
+    }
+  ]
+
+  ecs-task_name               = "pvsite_forecast"
+  ecs-task_type               = "forecast"
   ecs-task_execution_role_arn = module.ecs.ecs_task_execution_role_arn
-  sentry_dsn = var.sentry_dsn
+  ecs-task_size = {
+    memory = 4096
+    cpu    = 1024
+  }
+
+  container-env_vars = [
+    { "name" : "AWS_REGION", "value" : var.region },
+    { "name" : "OCF_ENVIRONMENT", "value" : local.environment },
+    { "name" : "LOGLEVEL", "value" : "DEBUG" },
+    { "name" : "NWP_ZARR_PATH", "value": "s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr" },
+    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn},
+  ]
+
+  container-secret_vars = [
+       {secret_policy_arn: module.pvsite_database.secret.arn,
+        values: ["OCF_PV_DB_URL"]
+       }
+       ]
+
+  container-tag         = var.pvsite_forecast_version
+  container-name        = "openclimatefix/pvsite_forecast"
+  container-registry    = "docker.io"
+  container-command     = []
 }
 
 # 6.5


### PR DESCRIPTION
# Pull Request

## Description

Removing forecast genertic on national-xg and pvsite forecast

## How Has This Been Tested?

Copied from dev

- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
