### PR TITLE
chore(forecast): Move pvnet to use GHCR

### DIFF
--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -678,8 +678,8 @@ source = "../../modules/services/ecs_task"
        ]
 
   container-tag         = var.forecast_pvnet_version
-  container-name        = "openclimatefix/pvnet_app"
-  container-registry    = "docker.io"
+  container-name        = "openclimatefix/uk-pvnet-app"
+  container-registry    = "ghcr.io"
   container-command     = []
 }
 
@@ -731,8 +731,8 @@ source = "../../modules/services/ecs_task"
        ]
 
   container-tag         = var.forecast_pvnet_version
-  container-name        = "openclimatefix/pvnet_app"
-  container-registry    = "docker.io"
+  container-name        = "openclimatefix/uk-pvnet-app"
+  container-registry    = "ghcr.io"
   container-command     = []
 }
 
@@ -790,8 +790,8 @@ source = "../../modules/services/ecs_task"
        ]
 
   container-tag         = var.forecast_pvnet_day_ahead_docker_version
-  container-name        = "openclimatefix/pvnet_app"
-  container-registry    = "docker.io"
+  container-name        = "openclimatefix/uk-pvnet-app"
+  container-registry    = "ghcr.io"
   container-command     = []
 }
 


### PR DESCRIPTION
Since https://github.com/openclimatefix/uk-pvnet-app/pull/202, the uk-pvnet-app has changed container registry to github.