### PR TITLE
only let one task of determine_latest_zarr_ecmwf run at once.

### DIFF
--- a/terraform/modules/services/airflow/dags/india/nwp-dag.py
+++ b/terraform/modules/services/airflow/dags/india/nwp-dag.py
@@ -13,7 +13,7 @@ default_args = {
     "start_date": datetime.now(tz=timezone.utc) - timedelta(hours=1.5),
     "retries": 1,
     "retry_delay": timedelta(minutes=1),
-    "max_active_runs": 10,
+    "max_active_runs": 1,
     "concurrency": 10,
     "max_active_tasks": 10,
 }

--- a/terraform/modules/services/airflow/dags/uk/nwp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/nwp-dag.py
@@ -14,7 +14,7 @@ default_args = {
     "start_date": datetime.now(tz=timezone.utc) - timedelta(hours=0.5),
     "retries": 1,
     "retry_delay": timedelta(minutes=1),
-    "max_active_runs": 10,
+    "max_active_runs": 1,
     "concurrency": 10,
     "max_active_tasks": 10,
 }


### PR DESCRIPTION
# Pull Request

## Description
only let once task of determine_latest_zarr_ecmwf run at once by setting max_active_runs = 1 both in uk and india code.

Fixes #

## How Has This Been Tested?

I need more insights on how to test this

- [ ] Yes

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
