### PR TITLE
remove duplicate env vars in nwp consumer

### DIFF
--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -225,23 +225,22 @@ module "nwp-ecmwf" {
   }]
 
   container-env_vars = [
-    { "name" : "MODEL_REPOSITORY", "value" : "ecmwf-realtime" },
-    { "name" : "AWS_REGION", "value" : "eu-west-1" },
-    { "name" : "ECMWF_REALTIME_S3_REGION", "value": "eu-west-1" },
-    { "name" : "ECMWF_REALTIME_S3_BUCKET", "value" : "ocf-ecmwf-production" },
-    { "name" : "ZARRDIR", "value" : "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data" },
-    { "name" : "LOGLEVEL", "value" : "DEBUG" },
-    { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
-    { "name" : "CONCURRENCY", "value" : "false" },
-    # legacy ones
-    { "name" : "AWS_S3_BUCKET", "value" : module.s3.s3-nwp-bucket.id },
-    { "name" : "ECMWF_AWS_REGION", "value": "eu-west-1" },
-    { "name" : "ECMWF_AWS_S3_BUCKET", "value" : "ocf-ecmwf-production" },
-    { "name" : "ECMWF_AREA", "value" : "uk" },
-    { "name" : "ENVIRONMENT", "value" : local.environment },
-    { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
-    { "name" : "LOGLEVEL", "value" : "DEBUG" }
-  ]
+  { "name" : "MODEL_REPOSITORY", "value" : "ecmwf-realtime" },
+  { "name" : "AWS_REGION", "value" : "eu-west-1" },
+  { "name" : "ECMWF_REALTIME_S3_REGION", "value": "eu-west-1" },
+  { "name" : "ECMWF_REALTIME_S3_BUCKET", "value" : "ocf-ecmwf-production" },
+  { "name" : "ZARRDIR", "value" : "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data" },
+  { "name" : "LOGLEVEL", "value" : "DEBUG" },
+  { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
+  { "name" : "CONCURRENCY", "value" : "false" },
+  # legacy ones
+  { "name" : "AWS_S3_BUCKET", "value" : module.s3.s3-nwp-bucket.id },
+  { "name" : "ECMWF_AWS_REGION", "value": "eu-west-1" },
+  { "name" : "ECMWF_AWS_S3_BUCKET", "value" : "ocf-ecmwf-production" },
+  { "name" : "ECMWF_AREA", "value" : "uk" },
+  { "name" : "ENVIRONMENT", "value" : local.environment }
+]
+
   container-secret_vars = [
   {secret_policy_arn: aws_secretsmanager_secret.nwp_consumer_secret.arn,
   values: ["ECMWF_REALTIME_S3_ACCESS_KEY", "ECMWF_REALTIME_S3_ACCESS_SECRET"]}

--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -212,23 +212,21 @@ module "nwp-ecmwf" {
   }]
 
   container-env_vars = [
-    { "name" : "MODEL_REPOSITORY", "value" : "ecmwf-realtime" },
-    { "name" : "AWS_REGION", "value" : "eu-west-1" },
-    { "name" : "ECMWF_REALTIME_S3_REGION", "value": "eu-west-1" },
-    { "name" : "ECMWF_REALTIME_S3_BUCKET", "value" : "ocf-ecmwf-production" },
-    { "name" : "ZARRDIR", "value" : "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data" },
-    { "name" : "LOGLEVEL", "value" : "DEBUG" },
-    { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
-    { "name" : "CONCURRENCY", "value" : "false" },
-    # legacy ones
-    { "name" : "AWS_S3_BUCKET", "value" : module.s3.s3-nwp-bucket.id },
-    { "name" : "ECMWF_AWS_REGION", "value": "eu-west-1" },
-    { "name" : "ECMWF_AWS_S3_BUCKET", "value" : "ocf-ecmwf-production" },
-    { "name" : "ECMWF_AREA", "value" : "uk" },
-    { "name" : "ENVIRONMENT", "value" : local.environment },
-    { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
-    { "name" : "LOGLEVEL", "value" : "DEBUG" }
-  ]
+  { "name" : "MODEL_REPOSITORY", "value" : "ecmwf-realtime" },
+  { "name" : "AWS_REGION", "value" : "eu-west-1" },
+  { "name" : "ECMWF_REALTIME_S3_REGION", "value": "eu-west-1" },
+  { "name" : "ECMWF_REALTIME_S3_BUCKET", "value" : "ocf-ecmwf-production" },
+  { "name" : "ZARRDIR", "value" : "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data" },
+  { "name" : "LOGLEVEL", "value" : "DEBUG" },
+  { "name" : "SENTRY_DSN", "value" : var.sentry_dsn },
+  { "name" : "CONCURRENCY", "value" : "false" },
+  # legacy ones
+  { "name" : "AWS_S3_BUCKET", "value" : module.s3.s3-nwp-bucket.id },
+  { "name" : "ECMWF_AWS_REGION", "value": "eu-west-1" },
+  { "name" : "ECMWF_AWS_S3_BUCKET", "value" : "ocf-ecmwf-production" },
+  { "name" : "ECMWF_AREA", "value" : "uk" },
+  { "name" : "ENVIRONMENT", "value" : local.environment }
+]
 
     container-secret_vars = [
   {secret_policy_arn: aws_secretsmanager_secret.nwp_consumer_secret.arn,


### PR DESCRIPTION
# Pull Request

## Description

This pull request addresses the issue of duplicate environment variables in the NWP consumer configuration for both development and production environments. The changes remove redundant entries for SENTRY_DSN and LOGLEVEL in the container-env_vars section of the Terraform configuration files.

Fixes #810


## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
