### PR TITLE
Add env var for new pvnet app version

### DIFF
--- a/terraform/modules/services/airflow/dags/uk/forecast-gsp-dag.py
+++ b/terraform/modules/services/airflow/dags/uk/forecast-gsp-dag.py
@@ -26,7 +26,7 @@ cluster = f"Nowcasting-{env}"
 # Tasks can still be defined in terraform, or defined here
 
 forecast_pvnet_error_message = (
-    "❌ The task {{ ti.task_id }} failed. This means all PVNet models including ECMWF-only have "
+    "❌ The task {{ ti.task_id }} failed. This means one or more of the critical PVNet models have "
     "failed to run. We have about 6 hours before the blend services need this. "
     "Please see run book for appropriate actions."
 )

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -704,7 +704,7 @@ source = "../../modules/services/ecs_task"
     { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true" },
     { "name" : "FILTER_BAD_FORECASTS", "value": "false" }, # On dev we save even the bad forecasts
     { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" },
-    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
+    { "name" : "RAISE_MODEL_FAILURE", "value": "critical" },
   ]
 
   container-secret_vars = [
@@ -763,7 +763,7 @@ source = "../../modules/services/ecs_task"
     { "name" : "DAY_AHEAD_MODEL",  "value": "true" },
     { "name" : "USE_OCF_DATA_SAMPLER", "value": "true" },
     { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" },
-    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
+    { "name" : "RAISE_MODEL_FAILURE", "value": "critical" },
   ]
 
   container-secret_vars = [

--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -694,16 +694,17 @@ source = "../../modules/services/ecs_task"
     { "name" : "ENVIRONMENT", "value" : local.environment },
     { "name" : "LOGLEVEL", "value" : "INFO" },
     { "name" : "NWP_ECMWF_ZARR_PATH", "value": "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data/latest.zarr" },
-    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr"},
-    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip"},
-    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn},
+    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr" },
+    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip" },
+    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn },
     { "name" : "RUN_CRITICAL_MODELS_ONLY", "value": "false" }, # On dev all models should run
     { "name" : "DAY_AHEAD_MODEL", "value": "false" },
     { "name" : "USE_OCF_DATA_SAMPLER", "value": "true" },
     { "name" : "ALLOW_ADJUSTER", "value": "true" },
     { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true" },
     { "name" : "FILTER_BAD_FORECASTS", "value": "false" }, # On dev we save even the bad forecasts
-    { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" }
+    { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" },
+    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
   ]
 
   container-secret_vars = [
@@ -754,14 +755,15 @@ source = "../../modules/services/ecs_task"
     { "name" : "ENVIRONMENT", "value" : local.environment },
     { "name" : "LOGLEVEL", "value" : "INFO" },
     { "name" : "NWP_ECMWF_ZARR_PATH", "value": "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data/latest.zarr" },
-    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr"},
-    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip"},
-    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn},
-    {"name": "ALLOW_ADJUSTER", "value": "true"},
-    {"name": "RUN_EXTRA_MODELS",  "value": "false"},
-    {"name": "DAY_AHEAD_MODEL",  "value": "true"},
-    {"name": "USE_OCF_DATA_SAMPLER", "value": "true"},
-    {"name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" }
+    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr" },
+    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip" },
+    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn },
+    { "name" : "ALLOW_ADJUSTER", "value": "true" },
+    { "name" : "RUN_EXTRA_MODELS",  "value": "false" },
+    { "name" : "DAY_AHEAD_MODEL",  "value": "true" },
+    { "name" : "USE_OCF_DATA_SAMPLER", "value": "true" },
+    { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" },
+    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
   ]
 
   container-secret_vars = [

--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -555,16 +555,17 @@ module "forecast_pvnet" {
     { "name" : "ENVIRONMENT", "value" : local.environment },
     { "name" : "LOGLEVEL", "value" : "INFO" },
     { "name" : "NWP_ECMWF_ZARR_PATH", "value": "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data/latest.zarr" },
-    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr"},
-    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip"},
-    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn},
+    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr" },
+    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip" },
+    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn },
     { "name" : "RUN_CRITICAL_MODELS_ONLY", "value": "true" }, # On prod only run critical models
     { "name" : "FILTER_BAD_FORECASTS", "value": "true" }, # On prod we don't save bad forecasts
-    { "name" : "ALLOW_ADJUSTER", "value": "true"},
-    { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true"},
-    { "name" : "DAY_AHEAD_MODEL",  "value": "false"},
-    { "name" : "USE_OCF_DATA_SAMPLER", "value": "false"}, # legacy model
+    { "name" : "ALLOW_ADJUSTER", "value": "true" },
+    { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true" },
+    { "name" : "DAY_AHEAD_MODEL",  "value": "false" },
+    { "name" : "USE_OCF_DATA_SAMPLER", "value": "false" }, # legacy model
     { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" }
+    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
   ]
 
   container-secret_vars = [
@@ -666,15 +667,16 @@ module "forecast_pvnet_day_ahead" {
     { "name" : "ENVIRONMENT", "value" : local.environment },
     { "name" : "LOGLEVEL", "value" : "INFO" },
     { "name" : "NWP_ECMWF_ZARR_PATH", "value": "s3://${module.s3.s3-nwp-bucket.id}/ecmwf/data/latest.zarr" },
-    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr"},
-    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip"},
-    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn},
+    { "name" : "NWP_UKV_ZARR_PATH", "value":"s3://${module.s3.s3-nwp-bucket.id}/data-metoffice/latest.zarr" },
+    { "name" : "SATELLITE_ZARR_PATH", "value":"s3://${module.s3.s3-sat-bucket.id}/data/latest/latest.zarr.zip" },
+    { "name" : "SENTRY_DSN",  "value": var.sentry_dsn },
     { "name" : "RUN_CRITICAL_MODELS_ONLY", "value": "false" }, # This needs to be False for DA
     { "name" : "FILTER_BAD_FORECASTS", "value": "true" }, # On prod we don't save bad forecasts
-    { "name" : "ALLOW_ADJUSTER", "value": "true"},
-    { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true"},
-    { "name" : "DAY_AHEAD_MODEL",  "value": "true"},
-    { "name" : "USE_OCF_DATA_SAMPLER", "value": "false"}, # legacy model
+    { "name" : "ALLOW_ADJUSTER", "value": "true" },
+    { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true" },
+    { "name" : "DAY_AHEAD_MODEL",  "value": "true" },
+    { "name" : "USE_OCF_DATA_SAMPLER", "value": "false" }, # legacy model
+    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
   ]
 
 

--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -564,7 +564,7 @@ module "forecast_pvnet" {
     { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true" },
     { "name" : "DAY_AHEAD_MODEL",  "value": "false" },
     { "name" : "USE_OCF_DATA_SAMPLER", "value": "false" }, # legacy model
-    { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" }
+    { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" },
     { "name" : "RAISE_MODEL_FAILURE", "value": "critical" },
   ]
 

--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -565,7 +565,7 @@ module "forecast_pvnet" {
     { "name" : "DAY_AHEAD_MODEL",  "value": "false" },
     { "name" : "USE_OCF_DATA_SAMPLER", "value": "false" }, # legacy model
     { "name" : "SAVE_BATCHES_DIR", "value": "s3://${module.forecasting_models_bucket.bucket_id}/pvnet_batches" }
-    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
+    { "name" : "RAISE_MODEL_FAILURE", "value": "critical" },
   ]
 
   container-secret_vars = [
@@ -676,7 +676,7 @@ module "forecast_pvnet_day_ahead" {
     { "name" : "ALLOW_SAVE_GSP_SUM", "value": "true" },
     { "name" : "DAY_AHEAD_MODEL",  "value": "true" },
     { "name" : "USE_OCF_DATA_SAMPLER", "value": "false" }, # legacy model
-    { "name" : "RAISE_MODEL_FAILURE", "value", "critical" },
+    { "name" : "RAISE_MODEL_FAILURE", "value": "critical" },
   ]
 
 


### PR DESCRIPTION
Add the new env var `RAISE_MODEL_FAILURE` for uk-pvnet-app (see [this PR](https://github.com/openclimatefix/uk-pvnet-app/pull/283) for details).

I have set `RAISE_MODEL_FAILURE="critical"` for both prod and dev. I think this is a good balance. We will only be notified by slack if one or more of the critical models does not run. 

On dev we are allowing the extra models to fail silently, but since they are only for monitoring purposes I think this is fine and we can pick that up from the internal analysis dashboard