### PR TITLE
update api start command after module rename

### DIFF
--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -95,7 +95,7 @@ module "api" {
   aws-environment    = local.environment
   aws-subnet_id      = module.networking.public_subnet_ids[0]
   aws-vpc_id         = module.networking.vpc_id
-  container-command  = ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "80"]
+  container-command  = ["uvicorn", "nowcasting_api.main:app", "--host", "0.0.0.0", "--port", "80"]
   container-env_vars = [
     { "name" : "DB_URL", "value" :  module.database.forecast-database-secret-url},
     { "name" : "ORIGINS", "value" : "*" },


### PR DESCRIPTION
# Pull Request

## Description

> For UK API **`v1.5.75`**

Update start command as the `src` module of the UK National API has now been renamed to `nowcasting_api` for prod API in order to update to latest API version above.

## How Has This Been Tested?

This is how it runs locally and through docker now.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
