### PR TITLE
change to 2 apis

### DIFF
--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -77,7 +77,7 @@ module "database" {
 
 # 1.1
 module "api" {
-  source             = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/eb_app?ref=17d6cfc"
+  source             = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/eb_app?ref=c967013"
   domain             = local.domain
   aws-region         = var.region
   aws-environment    = local.environment

--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -77,7 +77,7 @@ module "database" {
 
 # 1.1
 module "api" {
-  source             = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/eb_app?ref=72ba38d"
+  source             = "github.com/openclimatefix/ocf-infrastructure//terraform/modules/services/eb_app?ref=17d6cfc"
   domain             = local.domain
   aws-region         = var.region
   aws-environment    = local.environment
@@ -101,6 +101,7 @@ module "api" {
   container-registry = "openclimatefix"
   eb-app_name    = "nowcasting-api"
   eb-instance_type = "t3.medium"
+  eb_ec2_max_size = "2"
   s3_bucket = [
     { bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn },
     { bucket_read_policy_arn = module.s3.iam-policy-s3-sat-read.arn }

--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -101,7 +101,8 @@ module "api" {
   container-registry = "openclimatefix"
   eb-app_name    = "nowcasting-api"
   eb-instance_type = "t3.medium"
-  eb_ec2_max_size = "2"
+  min_ec2_count = 2
+  max_ec2_count = 2
   s3_bucket = [
     { bucket_read_policy_arn = module.s3.iam-policy-s3-nwp-read.arn },
     { bucket_read_policy_arn = module.s3.iam-policy-s3-sat-read.arn }


### PR DESCRIPTION
# Pull Request

## Description

Change UK production to 2 ec2 machines running the API. This gives extra reliances incase API goes down. 
note: Caching is per ec2 machine, so it could lead to a increase in data load on the database

#863 

## How Has This Been Tested?

- [x] CI test
- [x] tested on dev

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
