### PR TITLE
Add lifecycle rules for rss and odegree S3 prefixes

### DIFF
--- a/terraform/india/development/main.tf
+++ b/terraform/india/development/main.tf
@@ -77,7 +77,7 @@ module "s3-satellite-bucket" {
   region              = var.region
   domain              = local.domain
   service_name        = "satellite"
-  lifecycled_prefixes = ["data", "raw"]
+  lifecycled_prefixes = ["data", "raw", "rss", "odegree", "iodc"]
 }
 
 # 2.2

--- a/terraform/india/production/main.tf
+++ b/terraform/india/production/main.tf
@@ -76,7 +76,7 @@ module "s3-satellite-bucket" {
   region              = var.region
   domain              = local.domain
   service_name        = "satellite"
-  lifecycled_prefixes = ["data", "raw"]
+  lifecycled_prefixes = ["data", "raw", "rss", "odegree", "iodc"]
 }
 
 # 2.2

--- a/terraform/modules/storage/s3-trio/s3.tf
+++ b/terraform/modules/storage/s3-trio/s3.tf
@@ -144,4 +144,26 @@ resource "aws_s3_bucket_lifecycle_configuration" "sat-bucket-lifecycle" {
     status = "Enabled"
   }
 
+  rule {
+    id      = "remove_old_rss_files"
+    filter {
+      prefix = "rss/"
+    }
+    expiration {
+      days = 7
+    }
+    status = "Enabled"
+  }
+
+  rule {
+    id      = "remove_old_odegree_files"
+    filter {
+      prefix = "odegree/"
+    }
+    expiration {
+      days = 7
+    }
+    status = "Enabled"
+  }
+
 }


### PR DESCRIPTION
Update main.tf and s3

# Pull Request
Issue -  #889 

Added iodc prefix to satellite S3 lifecycle rules to ensure only 7 days of data are retained for all relevant satellite data directories.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
