### PR TITLE
chore(s3): Further increase lifecycling

### DIFF
--- a/terraform/modules/storage/s3-private/bucket.tf
+++ b/terraform/modules/storage/s3-private/bucket.tf
@@ -58,7 +58,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "lifecycle" {
           prefix = "${rule.value}/"
         }
         expiration {
-          days = 31
+          days = 40
         }
     }
   }


### PR DESCRIPTION
At @Sukh-P's request, ups the lifecycling to 40 days for data.

At some point, we should probably change this lifecycled_prefixes variable to be a list of objects instead of strings, so you could pass a tuple (prefix, integer) and lifecycle accordingly.