### PR TITLE
add apitally to quartz-api

### DIFF
--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -135,6 +135,7 @@ module "uk-national-quartz-api" {
     { "name" : "AUTH0_DOMAIN", "value" : var.auth_domain },
     { "name" : "AUTH0_AUDIENCE", "value" : var.auth_api_audience },
     { "name" : "AUTH0_RULE_NAMESPACE", "value" : "https://openclimatefix.org"},
+    { "name" : "APITALLY_CLIENT_ID", "value" : var.apitally_client_id},
     # legacy, we shouldnt need this in the future, 
     # but we need this for status in the mean time
     { "name" : "DB_URL", "value" : module.database.forecast-database-secret-url },
@@ -372,6 +373,7 @@ module "quartz-api" {
     { "name" : "ENVIRONMENT", "value": local.environment},
     { "name" : "DATA_PLATFORM_HOST", "value": module.data_platform_api.api_url}, 
     { "name" : "DATA_PLATFORM_PORT", "value": "50051"}, 
+    { "name" : "APITALLY_CLIENT_ID", "value" : var.apitally_client_id},
   ]
   container-name = "quartz-api"
   container-tag  = var.quartz-api

--- a/terraform/nowcasting/development/variables.tf
+++ b/terraform/nowcasting/development/variables.tf
@@ -99,3 +99,8 @@ variable "uk-national-quartz-api" {
   description = "Docker image tag for the uk national quartz api"
   default = "0.3.4"
 }
+
+variable "apitally_client_id" {
+  description = "The client id for APItally"
+  default = ""
+}


### PR DESCRIPTION
# Pull Request

## Description

Following on from https://github.com/openclimatefix/quartz-api/pull/168, this adds the env vars for api tally

## How Has This Been Tested?

- [x] CI tests

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
