### PR TITLE
add host_url and client id to quartz-apis

### DIFF
--- a/terraform/nowcasting/development/main.tf
+++ b/terraform/nowcasting/development/main.tf
@@ -9,6 +9,7 @@ This is the main terraform code for the UK platform. It is used to deploy the pl
 0.5 - S3 bucket for forecasters
 0.6 - Database
 1.1 - API
+1.2 - UK-National API
 2.1 - NWP Consumer Secret
 2.2 - Satellite Consumer Secret
 2.3 - PV Secret
@@ -135,10 +136,12 @@ module "uk-national-quartz-api" {
     { "name" : "AUTH0_DOMAIN", "value" : var.auth_domain },
     { "name" : "AUTH0_AUDIENCE", "value" : var.auth_api_audience },
     { "name" : "AUTH0_RULE_NAMESPACE", "value" : "https://openclimatefix.org"},
+    { "name" : "AUTH0_CLIENT_ID", "value": var.auth_client_id},
     { "name" : "APITALLY_CLIENT_ID", "value" : var.apitally_client_id},
     # legacy, we shouldnt need this in the future, 
     # but we need this for status in the mean time
     { "name" : "DB_URL", "value" : module.database.forecast-database-secret-url },
+    { "name" : "HOST_URL", "value":"http://uk-development-uk-national-quartz-api.eu-west-1.elasticbeanstalk.com"}
   ]
   container-name = "quartz-api"
   container-tag  = var.uk-national-quartz-api
@@ -369,11 +372,13 @@ module "quartz-api" {
     { "name" : "DB_URL", "value" : module.database.forecast-database-secret-url },
     { "name" : "AUTH0_DOMAIN", "value" : var.auth_domain },
     { "name" : "AUTH0_AUDIENCE", "value" : var.auth_api_audience },
+    { "name" : "AUTH0_CLIENT_ID", "value": var.auth_client_id},
     { "name" : "SENTRY_DSN", "value" : var.sentry_dsn_api },
     { "name" : "ENVIRONMENT", "value": local.environment},
     { "name" : "DATA_PLATFORM_HOST", "value": module.data_platform_api.api_url}, 
     { "name" : "DATA_PLATFORM_PORT", "value": "50051"}, 
     { "name" : "APITALLY_CLIENT_ID", "value" : var.apitally_client_id},
+    { "name" : "HOST_URL", "value":"http://uk-development-quartz-api.eu-west-1.elasticbeanstalk.com"}
   ]
   container-name = "quartz-api"
   container-tag  = var.quartz-api

--- a/terraform/nowcasting/development/variables.tf
+++ b/terraform/nowcasting/development/variables.tf
@@ -38,6 +38,11 @@ variable "airflow_auth_username" {
     default     = "not-set"
 }
 
+variable "auth_client_id" {
+  description = "The Auth client id that should be used"
+  default     = "not-set"
+}
+
 variable "airflow_auth_password" {
     description = "The Auth username for airflow that should be used"
     default     = "not-set"


### PR DESCRIPTION
# Pull Request

## Description

Add HOST_URL and AUTH0_CLIENT_ID to quartz-api

## How Has This Been Tested?

- This only makes changes to documenation, not to code

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
