### PR TITLE
Fix Broken Documentation Links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ folders within the `terraform` directory, along with reusable modules and unitte
 ocf-infrastructure:
   terraform: # Contains all the terraform code for OCF's cloud infrastructure
     modules: # Portable terraform modules defining specific cloud infrastructure blocks
-    nowcasting: # Specific code for the nowcasting domain's cloud infrastructure
-    pvsite: # Specific code for the nowcasting domain's cloud infrastruture
+    nowcasting: # Specific code for the nowcasting domain's cloud infrastructure (includes PV site services)
+      development: # Development environment configuration
+      production: # Production environment configuration
+    india: # India-specific infrastructure
     unittests: # Specific infrastructure code for a environment to test the modules
   local-stack: # Code to run the terraform stack locally for local testing/development
   .github: # Contains github-specific code for automated CI workflows
 ```
 
 See the README's in the domain folders for more information on their architecture:
-- [Nowcasting Domain](terraform/nowcasting/README.md)
-- [PVSite Domain](terraform/pvsite/README.md)
+- [Nowcasting Domain (Development)](terraform/nowcasting/development/README.md)
+- [Nowcasting Domain (Production)](terraform/nowcasting/production/README.md)
 - [Modules](terraform/modules/README.md)
 
 


### PR DESCRIPTION
## Description

This PR fixes broken documentation links in the main [README.md](README.md) that were causing 404 errors when users attempted to access architecture documentation for the nowcasting and pvsite domains and closes issue #698

## Problem

The README.md contained two broken links:
1. **Line 46**: `[Nowcasting Domain](terraform/nowcasting/README.md)` → **404 Error**
2. **Line 47**: `[PVSite Domain](terraform/pvsite/README.md)` → **404 Error**

### Root Cause

- The `terraform/nowcasting/README.md` file does not exist. Documentation has been organized into environment-specific subdirectories (`development/` and `production/`)
- The `terraform/pvsite/` directory does not exist. PV site infrastructure is integrated within the nowcasting domain, not maintained as a separate domain

## Changes Made

### 1. Updated Repository Structure Diagram (Lines 34-45)

**Before:**
```yaml
ocf-infrastructure:
  terraform:
    modules:
    nowcasting:
    pvsite: # This directory doesn't exist
    unittests:
```

**After:**
```yaml
ocf-infrastructure:
  terraform:
    modules:
    nowcasting: # (includes PV site services)
      development:
      production:
    india:
    unittests:
```

### 2. Fixed Documentation Links (Lines 47-50)

**Before:**
```markdown
- [Nowcasting Domain](terraform/nowcasting/README.md)
- [PVSite Domain](terraform/pvsite/README.md)
- [Modules](terraform/modules/README.md)
```

**After:**
```markdown
- [Nowcasting Domain (Development)](terraform/nowcasting/development/README.md)
- [Nowcasting Domain (Production)](terraform/nowcasting/production/README.md)
- [Modules](terraform/modules/README.md)
```

## Testing & Verification

All referenced files exist:
- `terraform/nowcasting/development/README.md` (116 lines)
- `terraform/nowcasting/production/README.md` (116 lines)
- `terraform/modules/README.md`

Confirmed `terraform/pvsite/` directory does not exist

No remaining references to broken paths in the codebase

## Impact

- **Before**: Users clicking on documentation links received 404 errors, blocking access to infrastructure architecture information
- **After**: All documentation links work correctly, directing users to the appropriate environment-specific documentation

## Related Discussion

This fix was suggested by @peterdudfield in [issue #698](https://github.com/openclimatefix/ocf-infrastructure/issues/698#issuecomment-2659355847) on Feb 6, 2025.

## Checklist

- [x] Updated repository structure diagram to match actual directory layout
- [x] Fixed broken documentation links
- [x] Verified all linked files exist
- [x] Searched for any other similar broken references
- [x] Tested links point to correct files
