### PR TITLE
Downgrade RDS engine version from 18.2 to 17.4

### DIFF
--- a/terraform/nowcasting/production/main.tf
+++ b/terraform/nowcasting/production/main.tf
@@ -251,7 +251,7 @@ module "data_platform_database" {
   db_name                     = "dataplatform"
   rds_instance_class          = "db.t3.small"
   allow_major_version_upgrade = true
-  engine_version = "18.2"
+  engine_version = "17.4"
 }
 
 # 6.1 Data Platform - API


### PR DESCRIPTION
# Pull Request

## Description

Downgrade data-platform to 17.4
postgis_topology not available yet - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.PostgreSQL.MajorVersion.Process.html

Fixes #

## How Has This Been Tested?

 - [ ] tried on dev first

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
